### PR TITLE
Potential fix for code scanning alert no. 3: Double escaping or unescaping

### DIFF
--- a/src/utils/sanitizer.ts
+++ b/src/utils/sanitizer.ts
@@ -4,11 +4,11 @@ export const sanitizeHtml = (html: string): string => {
     return DOMPurify.sanitize(html)
         .replace(/<[^>]*>/g, '')
         .replace(/&nbsp;/g, ' ')
-        .replace(/&amp;/g, '&')
         .replace(/&lt;/g, '<')
         .replace(/&gt;/g, '>')
         .replace(/&quot;/g, '"')
         .replace(/&#39;/g, "'")
+        .replace(/&amp;/g, '&')
         .replace(/\s+/g, ' ')
         .trim()
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Lands-Horizon-Corp/e-coop-client/security/code-scanning/3](https://github.com/Lands-Horizon-Corp/e-coop-client/security/code-scanning/3)

To fix the problem, we need to change the order of the `.replace()` calls so that `&amp;` is unescaped last, after all other HTML entities have been replaced. This prevents cases where an entity like `&amp;quot;` is incorrectly decoded to `"` instead of `&quot;`. The change should be made in the `sanitizeHtml` function in `src/utils/sanitizer.ts`, specifically by moving the `.replace(/&amp;/g, '&')` line to after all other entity replacements. No new imports or methods are needed; just a reordering of the existing lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
