### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality-ci.yml
+++ b/.github/workflows/code-quality-ci.yml
@@ -1,5 +1,8 @@
 name: Quality Checks Pipeline
 
+permissions:
+  contents: read
+
 on:
     push:
         branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Lands-Horizon-Corp/e-coop-client/security/code-scanning/8](https://github.com/Lands-Horizon-Corp/e-coop-client/security/code-scanning/8)

The best way to fix this issue is to add a `permissions` key to either the root level of the workflow or at the job level. Since there's only one job (`code_quality`), either placement is fine and will have the same effect, but placing it at the workflow root keeps the configuration clear and helps enforce minimum privilege for future jobs by default. For this workflow, only read access to repository contents is needed, so the minimal required is:

```yaml
permissions:
  contents: read
```

This should be added after the `name` declaration and before `on:` at lines 2–3. No other lines need changing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
