### PR TITLE
Potential fix for code scanning alert no. 9: Double escaping or unescaping

### DIFF
--- a/src/helpers/sanitizer.ts
+++ b/src/helpers/sanitizer.ts
@@ -3,11 +3,11 @@ import DOMPurify from 'dompurify'
 export const sanitizeHtml = (html: string): string => {
     return DOMPurify.sanitize(html, { ALLOWED_TAGS: [] })
         .replace(/&nbsp;/g, ' ')
-        .replace(/&amp;/g, '&')
         .replace(/&lt;/g, '<')
         .replace(/&gt;/g, '>')
         .replace(/&quot;/g, '"')
         .replace(/&#39;/g, "'")
+        .replace(/&amp;/g, '&')
         .replace(/\s+/g, ' ')
         .trim()
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Lands-Horizon-Corp/e-coop-client/security/code-scanning/9](https://github.com/Lands-Horizon-Corp/e-coop-client/security/code-scanning/9)

To fix the problem, reorder the `.replace` calls so that `&amp;` is replaced *after* the others. This means all the entity replacements for `&nbsp;`, `&lt;`, `&gt;`, `&quot;`, and `&#39;` should be done first. The final `.replace(/&amp;/g, '&')` will then unescape any ampersands from the actual entities, preventing premature unescaping of nested entities (such as `&amp;quot;`). Edit the function in `src/helpers/sanitizer.ts`, changing the order so `replace(/&amp;/g, '&')` appears after other entity replacements, just before whitespace normalization and trimming.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
